### PR TITLE
Add multipage PDF saving

### DIFF
--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -18,6 +18,7 @@ from matplotlib.transforms import ScaledTranslation
 from matplotlib.figure import Figure, SubFigure
 from matplotlib.axes import Axes
 from matplotlib.projections import get_projection_names
+from matplotlib.backends.backend_pdf import PdfPages
 
 from .file_manager import (
     FileLoader,
@@ -1225,9 +1226,10 @@ class SmartFigure:
 
     def save(
         self,
-        file_name: str,
+        file_name: str | PdfPages,
         dpi: Optional[int] = None,
         transparent: bool = False,
+        split_pdf: bool = False,
     ) -> Self:
         """
         Saves the :class:`~graphinglib.smart_figure.SmartFigure` to a file.
@@ -1236,11 +1238,15 @@ class SmartFigure:
         ----------
         file_name : str
             The name of the file to save the figure to. The file extension determines the format (e.g., .png, .pdf).
+            If a :class:`~matplotlib.backends.backend_pdf.PdfPages` object is provided, the figure will be saved to
+            that PDF file instead.
         dpi : int, optional
             The resolution in dots per inch. If None, the figure's DPI is used.
         transparent : bool, optional
             Whether to save the figure with a transparent background.
             Defaults to ``False``.
+        split_pdf : bool, optional
+            If True, the subplots of the SmartFigure will be saved as separate pages in a PDF file.
 
         Returns
         -------
@@ -1248,12 +1254,32 @@ class SmartFigure:
             The same SmartFigure instance, allowing for method chaining.
         """
         self._initialize_parent_smart_figure()
-        plt.savefig(
-            file_name,
-            bbox_inches="tight",
-            dpi=dpi if dpi is not None else "figure",
-            transparent=transparent,
-        )
+
+        if isinstance(file_name, PdfPages) or split_pdf:
+            name = file_name if not isinstance(file_name, PdfPages) else file_name._filename
+            if not name.endswith(".pdf"):
+                name = f"{''.join(name.split('.')[:-1])}.pdf"
+                file_name = name if not isinstance(file_name, PdfPages) else PdfPages(name)
+                warning("File extension was changed to '.pdf' to allow for splitting the figure into PdfPages.")
+
+        if isinstance(file_name, PdfPages):
+            file_name.savefig(self._figure, bbox_inches="tight", dpi=dpi if dpi is not None else "figure")
+        elif split_pdf:
+            with PdfPages(file_name) as pdf:
+                for element in self._ordered_elements.values():
+                    if isinstance(element, (Plottable, list)):
+                        subfig = self.copy_with(elements=[element], num_rows=1, num_cols=1)
+                    elif isinstance(element, SmartFigure):
+                        subfig = element
+                    subfig.save(pdf, dpi)
+        else:
+            plt.savefig(
+                file_name,
+                bbox_inches="tight",
+                dpi=dpi if dpi is not None else "figure",
+                transparent=transparent,
+            )
+        
         plt.close()
         plt.rcParams.update(plt.rcParamsDefault)
         self._figure = None

--- a/unit_testing/smart_figure_test.py
+++ b/unit_testing/smart_figure_test.py
@@ -872,11 +872,9 @@ class TestSmartFigure(unittest.TestCase):
         self.assertTrue(os.path.exists("test_smart_figure_output.pdf"))
         os.remove("test_smart_figure_output.pdf")
         # Test saving with split_pdf and a non-PDF extension
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertLogs(level='WARNING') as log:
             self.fig.save("test_smart_figure_output.png", split_pdf=True)
-            self.assertTrue(len(w) > 0)
-            self.assertTrue(any("File extension" in str(warning.message) for warning in w))
+            self.assertTrue(any("File extension" in record for record in log.output))
         self.assertTrue(os.path.exists("test_smart_figure_output.pdf"))
         os.remove("test_smart_figure_output.pdf")
 

--- a/unit_testing/smart_figure_test.py
+++ b/unit_testing/smart_figure_test.py
@@ -7,6 +7,7 @@ from matplotlib import use as matplotlib_use
 matplotlib_use("Agg")  # Use non-GUI backend for tests
 
 from matplotlib import pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
 from numpy import linspace, sin, pi, array
 from astropy.wcs import WCS
 import astropy.units as u
@@ -861,6 +862,23 @@ class TestSmartFigure(unittest.TestCase):
         self.fig.save("test_smart_figure_output.png")
         self.assertTrue(os.path.exists("test_smart_figure_output.png"))
         os.remove("test_smart_figure_output.png")
+        # Test saving with PdfPages
+        with PdfPages("test_smart_figure_output.pdf") as pdf:
+            self.fig.save(pdf)
+        self.assertTrue(os.path.exists("test_smart_figure_output.pdf"))
+        os.remove("test_smart_figure_output.pdf")
+        # Test saving with split_pdf
+        self.fig.save("test_smart_figure_output.pdf", split_pdf=True)
+        self.assertTrue(os.path.exists("test_smart_figure_output.pdf"))
+        os.remove("test_smart_figure_output.pdf")
+        # Test saving with split_pdf and a non-PDF extension
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.fig.save("test_smart_figure_output.png", split_pdf=True)
+            self.assertTrue(len(w) > 0)
+            self.assertTrue(any("File extension" in str(warning.message) for warning in w))
+        self.assertTrue(os.path.exists("test_smart_figure_output.pdf"))
+        os.remove("test_smart_figure_output.pdf")
 
     def test_auto_assign_default_params(self):
         """Test automatic assignment of default parameters."""


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

### Added features
- Allows users to save multiple `SmartFigure`s in a single PDF by accepting `~matplotlib.backends.backend_pdf.PdfPages` objects as `file_name` argument in `SmartFigure.save()`.
- Allows users to split the subplots of a single `SmartFigure` into different pages of a single PDF by adding the argument `split_pdf` to `SmartFigure.save()`. This feature works best when subplots are imbedded `SmartFigure`s but also works for `Plottable` and `list` objects.
- Convert the saved file name to the correct extension whenever `split_pdf=True` or `file_name` is a `~matplotlib.backends.backend_pdf.PdfPages` object with a file name ending with something other than '.pdf'

### Usage exemple
```python
x = np.linspace(0, 10, 100)

curve = Curve(x, np.sin(x), label='sin')
scatter = Scatter(x, np.cos(x), label='cos', face_color='orange')

# Splitting subfigures into separate pages in a PDF
fig = SmartFigure(1, 2, elements=[curve, scatter])
fig.save("split_pdf_test.pdf", split_pdf=True)

# Saving multiple figures to a multipage PDF
with PdfPages("multipage_pdf_test.pdf") as pdf:
    for plottable in [curve, scatter]:
        SmartFigure(elements=[plottable]).save(pdf)
```

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A ] Links to the related issue (#....)
